### PR TITLE
Tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ waves.vcd
 
 pubspec.lock
 .vscode
+
+*.tracker.json
+*.tracker.log

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ The `Test` object contains settings for `killLevel` and `failLevel` which will, 
 
 To log a message from any ROHD-VF object or component, just use the inherited `logger` object.
 
+### Logging with the `Tracker`
+ROHD-VF comes with a flexible [`Tracker`](https://intel.github.io/rohd-vf/rohd_vf/Tracker-class.html) which enables pretty printing and convenient output files associated with arbitrary events (which implement [`Trackable`](https://intel.github.io/rohd-vf/rohd_vf/Trackable-class.html)) throughout your test.  `Tracker` currently supports a JSON output as well as an ASCII table output.  Check out the [tracker unit test](./test/tracker_test.dart) for an example of how to configure and use the `Tracker`.
+
 ----------------
 2021 November 9  
 Author: Max Korbel <<max.korbel@intel.com>>

--- a/example/counter.dart
+++ b/example/counter.dart
@@ -57,7 +57,7 @@ class Counter extends Module {
 
     nextVal <= val + 1;
 
-    FF(clk, [
+    Sequential(clk, [
       If(reset, then: [
         val < 0
       ], orElse: [

--- a/lib/rohd_vf.dart
+++ b/lib/rohd_vf.dart
@@ -12,3 +12,4 @@ export 'src/phase.dart';
 export 'src/test.dart';
 export 'src/rohdvf_object.dart';
 export 'src/monitor.dart';
+export 'src/tracker.dart';

--- a/lib/src/phase.dart
+++ b/lib/src/phase.dart
@@ -47,6 +47,11 @@ class Objection {
   }
 }
 
+/// A object responsible for controlling a period of time during the test
+/// which can be prevented from ending.
+///
+/// Raising [Objection]s on a [Phase] keeps this portion of the test from
+/// completing.
 class Phase {
   /// All active [Objection]s to this phase completing.
   final Queue<Objection> _objections = Queue<Objection>();

--- a/lib/src/tracker.dart
+++ b/lib/src/tracker.dart
@@ -1,0 +1,208 @@
+import 'dart:io';
+import 'dart:math';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+// import 'package:rohd/rohd.dart';
+
+enum Justify { right, left, center }
+
+class TrackerField {
+  final int columnWidth;
+  final String title;
+  final String emptyFill;
+  final Justify justify;
+  const TrackerField(this.title, this.columnWidth,
+      {this.emptyFill = '', this.justify = Justify.right});
+}
+
+abstract class Trackable {
+  String? trackerString(TrackerField field);
+}
+
+enum TrackerStyle { table, json }
+
+class Tracker<TrackableType extends Trackable> {
+  final String? outputFolder;
+
+  final bool dumpTable, dumpJson;
+
+  String get _fileNameStart {
+    var fileNameStart = name;
+    if (outputFolder != null) {
+      fileNameStart = outputFolder! + '/' + fileNameStart;
+    }
+    return fileNameStart;
+  }
+
+  String get jsonFileName => '$_fileNameStart.tracker.json';
+  String get logFileName => '$_fileNameStart.tracker.log';
+
+  final String name;
+  late final List<_TrackerDumper<TrackableType>> _dumpers;
+  Tracker(this.name, List<TrackerField> fields,
+      {String spacer = ' | ',
+      String separator = '-',
+      String overflow = '*',
+      this.outputFolder,
+      this.dumpTable = true,
+      this.dumpJson = true}) {
+    var fileNameStart = name;
+    if (outputFolder != null) {
+      fileNameStart = outputFolder! + '/' + fileNameStart;
+    }
+    _dumpers = [
+      if (dumpJson) _JsonDumper<TrackableType>(jsonFileName, fields),
+      if (dumpTable)
+        _TableDumper<TrackableType>(logFileName, fields,
+            spacer: spacer, separator: separator, overflow: overflow)
+    ];
+  }
+
+  void record(TrackableType trackable) {
+    for (var dumper in _dumpers) {
+      dumper.record(trackable);
+    }
+  }
+
+  Future<void> terminate() async {
+    for (var dumper in _dumpers) {
+      dumper.terminate();
+    }
+  }
+}
+
+abstract class _TrackerDumper<TrackableType extends Trackable> {
+  final List<TrackerField> _fields;
+  final File _file;
+  _TrackerDumper(String fileName, List<TrackerField> fields)
+      : _fields = List.from(fields),
+        _file = File(fileName) {
+    _file.writeAsStringSync(''); // empty out existing files
+  }
+
+  void logln(String message) {
+    _file.writeAsStringSync(message + '\n', mode: FileMode.append);
+  }
+
+  void record(TrackableType trackable);
+
+  void terminate() {}
+}
+
+class _TableDumper<TrackableType extends Trackable>
+    extends _TrackerDumper<TrackableType> {
+  final String spacer;
+  final String separator;
+  final String overflow;
+  _TableDumper(String fileName, List<TrackerField> fields,
+      {required this.spacer, required this.separator, required this.overflow})
+      : super(fileName, fields) {
+    _recordHeader();
+  }
+
+  @override
+  void record(TrackableType trackable) {
+    _recordLine(
+        {for (var field in _fields) field: trackable.trackerString(field)});
+  }
+
+  void _recordHeader() {
+    var headerHeight =
+        _fields.map((field) => field.title.length).reduce((a, b) => max(a, b));
+
+    _recordSeparator();
+    for (var charIdx = 0; charIdx < headerHeight; charIdx++) {
+      var entry = <TrackerField, String>{};
+      for (var field in _fields) {
+        if (charIdx < field.title.length) {
+          entry[field] = field.title[charIdx];
+        }
+      }
+      _recordLine(entry,
+          justify: Justify.left, emptyFill: '', includeMap: false);
+    }
+
+    _recordSeparator();
+  }
+
+  void _recordSeparator() {
+    logln(List.generate(
+        _fields
+                .map((field) => field.columnWidth + spacer.length)
+                .reduce((l1, l2) => l1 + l2) +
+            spacer.length,
+        (index) => separator).join());
+  }
+
+  void _recordLine(Map<TrackerField, String?> entry,
+      {Justify? justify, String? emptyFill, bool includeMap = true}) {
+    var fieldVals = _fields.map((field) {
+      var value = entry[field] ?? emptyFill ?? field.emptyFill;
+      var fieldJustify = justify ?? field.justify;
+
+      if (value.length > field.columnWidth) {
+        if (overflow.length > field.columnWidth) {
+          value = overflow.substring(0, field.columnWidth);
+        } else {
+          value = value.substring(0, field.columnWidth - overflow.length) +
+              overflow;
+        }
+      }
+
+      int leftPadding = 0, rightPadding = 0;
+      var totalPadding = field.columnWidth - value.length;
+
+      if (fieldJustify == Justify.left) {
+        rightPadding = totalPadding;
+      } else if (fieldJustify == Justify.right) {
+        leftPadding = totalPadding;
+      } else if (fieldJustify == Justify.center) {
+        leftPadding = totalPadding ~/ 2;
+        rightPadding = totalPadding - leftPadding;
+      }
+      var leftPaddingStr = List.generate(leftPadding, (index) => ' ').join();
+      var rightPaddingStr = List.generate(rightPadding, (index) => ' ').join();
+      return leftPaddingStr + value + rightPaddingStr;
+    });
+
+    var map = {for (var field in _fields) field.title: entry[field]};
+    var line = [...fieldVals, if (includeMap) map.toString()].join(spacer);
+    logln(spacer + line);
+  }
+}
+
+class _JsonDumper<TrackableType extends Trackable>
+    extends _TrackerDumper<TrackableType> {
+  _JsonDumper(String fileName, List<TrackerField> fields)
+      : super(fileName, fields) {
+    _recordStart();
+  }
+
+  void _recordStart() {
+    logln('{"records":[');
+  }
+
+  void _recordEnd() {
+    logln(']}');
+  }
+
+  bool _isFirst = true;
+  @override
+  void record(TrackableType trackable) {
+    var start = _isFirst ? ' ' : ',';
+    _isFirst = false;
+    var map = {
+      for (var field in _fields)
+        '"${field.title}"': '"${trackable.trackerString(field)}"'
+    };
+    logln('$start $map');
+  }
+
+  // TODO: add some sort of clean-up stage at the end of a test for stuff like this
+
+  @override
+  void terminate() {
+    _recordEnd();
+    super.terminate();
+  }
+}

--- a/lib/src/tracker.dart
+++ b/lib/src/tracker.dart
@@ -1,31 +1,64 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// tracker.dart
+/// A tracker to generate pretty and convenient logs from events
+///
+/// 2021 December 7
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
 import 'dart:io';
 import 'dart:math';
-import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
-// import 'package:rohd/rohd.dart';
 
+/// Selection of how to align text in a column.
 enum Justify { right, left, center }
 
+/// A field or column in a [Tracker] log.
 class TrackerField {
+  /// The width (in characters) of a column for a [Tracker] log.
   final int columnWidth;
+
+  /// The title and name of a column for a [Tracker] log.
   final String title;
+
+  /// A [String] to use to fill a column for a row where no data is provided.
   final String emptyFill;
+
+  /// How the data should be aligned with a column of a [Tracker] log.
   final Justify justify;
+
   const TrackerField(this.title, this.columnWidth,
-      {this.emptyFill = '', this.justify = Justify.right});
+      {this.emptyFill = '', this.justify = Justify.right})
+      : assert(columnWidth > 0);
 }
 
+/// An interface for an object that can be tracked by a [Tracker].
+///
+/// Any item that `implements` this class can be tracked.
 abstract class Trackable {
+  /// Returns a formatted [String] value associated with [field] in this object.
   String? trackerString(TrackerField field);
 }
 
-enum TrackerStyle { table, json }
-
+/// A logger that tracks a sequence of [Trackable] events into multiple output formats.
+///
+/// By default, [Tracker] outputs to both a ASCII table format (*.tracker.log) and a
+/// JSON format (*.tracker.json).
 class Tracker<TrackableType extends Trackable> {
+  /// An optional output directory for the logs.
+  ///
+  /// By default, if null, files will dump to the current working directory.
   final String? outputFolder;
 
-  final bool dumpTable, dumpJson;
+  /// If true, will dump an ASCII table log to [tableFileName].
+  final bool dumpTable;
 
+  /// If true, will dump a JSON file log to [jsonFileName].
+  final bool dumpJson;
+
+  /// The name of the file without an extension and including
+  /// the directory, if applicable.
   String get _fileNameStart {
     var fileNameStart = name;
     if (outputFolder != null) {
@@ -34,11 +67,18 @@ class Tracker<TrackableType extends Trackable> {
     return fileNameStart;
   }
 
+  /// The path to the generated JSON log file, if enabled by [dumpJson].
   String get jsonFileName => '$_fileNameStart.tracker.json';
-  String get logFileName => '$_fileNameStart.tracker.log';
 
+  /// The path to the generated ASCII table log file, if enabled by [dumpTable].
+  String get tableFileName => '$_fileNameStart.tracker.log';
+
+  /// The name of this [Tracker], used for naming output files.
   final String name;
+
+  /// A [List] of all [_TrackerDumper]s which are enabled for output dumping.
   late final List<_TrackerDumper<TrackableType>> _dumpers;
+
   Tracker(this.name, List<TrackerField> fields,
       {String spacer = ' | ',
       String separator = '-',
@@ -53,17 +93,22 @@ class Tracker<TrackableType extends Trackable> {
     _dumpers = [
       if (dumpJson) _JsonDumper<TrackableType>(jsonFileName, fields),
       if (dumpTable)
-        _TableDumper<TrackableType>(logFileName, fields,
+        _TableDumper<TrackableType>(tableFileName, fields,
             spacer: spacer, separator: separator, overflow: overflow)
     ];
   }
 
+  /// Records [trackable] into all enabled logs.
   void record(TrackableType trackable) {
     for (var dumper in _dumpers) {
       dumper.record(trackable);
     }
   }
 
+  /// Cleans up and finalizes all logs.
+  ///
+  /// If this is not called, the logs may be left in an
+  /// incomplete/invalid format.
   Future<void> terminate() async {
     for (var dumper in _dumpers) {
       dumper.terminate();
@@ -71,24 +116,48 @@ class Tracker<TrackableType extends Trackable> {
   }
 }
 
+/// A generic interface for an object which dumps to a log file
+/// for a [Tracker].
 abstract class _TrackerDumper<TrackableType extends Trackable> {
+  /// All the [TrackerField]s to be dumped in the intended order.
   final List<TrackerField> _fields;
+
+  /// The [File] to dump output to.
   final File _file;
+
+  /// Constructs a new [_TrackerDumper], erasing any existing file with the same name.
   _TrackerDumper(String fileName, List<TrackerField> fields)
       : _fields = List.from(fields),
         _file = File(fileName) {
     _file.writeAsStringSync(''); // empty out existing files
   }
 
+  /// Prints [message] to [_file], with a new line at the end.
   void logln(String message) {
+    if (_hasTerminated) {
+      throw Exception('Log has already terminated, cannot log more!');
+    }
     _file.writeAsStringSync(message + '\n', mode: FileMode.append);
   }
 
+  /// Logs [trackable] into the log controlled by this [_TrackerDumper].
   void record(TrackableType trackable);
 
-  void terminate() {}
+  /// Keeps track if this has already performed a termination.
+  bool _hasTerminated = false;
+
+  /// Performs any clean-up or file ending at the end of the log.
+  ///
+  /// No more can be logged after this is called.
+  void terminate() {
+    if (_hasTerminated) {
+      throw Exception('Already terminated.');
+    }
+    _hasTerminated = true;
+  }
 }
 
+/// A dumper for ASCII tables.
 class _TableDumper<TrackableType extends Trackable>
     extends _TrackerDumper<TrackableType> {
   final String spacer;
@@ -106,6 +175,7 @@ class _TableDumper<TrackableType extends Trackable>
         {for (var field in _fields) field: trackable.trackerString(field)});
   }
 
+  /// Prints the table header with vertically printed titles and separators.
   void _recordHeader() {
     var headerHeight =
         _fields.map((field) => field.title.length).reduce((a, b) => max(a, b));
@@ -166,11 +236,15 @@ class _TableDumper<TrackableType extends Trackable>
     });
 
     var map = {for (var field in _fields) field.title: entry[field]};
-    var line = [...fieldVals, if (includeMap) map.toString()].join(spacer);
+    var line = [
+      ...fieldVals,
+      if (includeMap) map.toString() else '',
+    ].join(spacer);
     logln(spacer + line);
   }
 }
 
+/// A dumper for JSON files.
 class _JsonDumper<TrackableType extends Trackable>
     extends _TrackerDumper<TrackableType> {
   _JsonDumper(String fileName, List<TrackerField> fields)
@@ -197,8 +271,6 @@ class _JsonDumper<TrackableType extends Trackable>
     };
     logln('$start $map');
   }
-
-  // TODO: add some sort of clean-up stage at the end of a test for stuff like this
 
   @override
   void terminate() {

--- a/test/tracker_test.dart
+++ b/test/tracker_test.dart
@@ -43,7 +43,7 @@ void main() {
       [
         TrackerField('Apple', 10),
         TrackerField('Banana', 5),
-        TrackerField('Carrot', 12)
+        TrackerField('Carrot', 12, justify: Justify.center)
       ],
     );
 
@@ -51,16 +51,34 @@ void main() {
     tracker.record(
         FruitEvent(LogicValues.fromString('1x01111000011010101'), 'aaa', 4));
 
+    // Expect JSON log to look like:
+    // {"records":[
+    //   {"Apple": "3'b1x0", "Banana": "banana", "Carrot": "25"}
+    // , {"Apple": "19'b1x01111000011010101", "Banana": "aaa", "Carrot": "4"}
+    // ]}
+
     tracker.terminate();
 
     var jsonOutput = json.decode(File(tracker.jsonFileName).readAsStringSync());
     expect(jsonOutput['records'].length, equals(2));
     expect(jsonOutput['records'][0]['Banana'], equals('banana'));
 
-    var logOutput = File(tracker.logFileName).readAsStringSync();
+    // Expect table log to look like:
+    // ---------------------------------------
+    //  | A          | B     | C
+    //  | p          | a     | a
+    //  | p          | n     | r
+    //  | l          | a     | r
+    //  | e          | n     | o
+    //  |            | a     | t
+    // ---------------------------------------
+    //  |     3'b1x0 | bana* |      25      | {Apple: 3'b1x0, Banana: banana, Carrot: 25}
+    //  | 19'b1x011* |   aaa |      4       | {Apple: 19'b1x01111000011010101, Banana: aaa, Carrot: 4}
+
+    var logOutput = File(tracker.tableFileName).readAsStringSync();
     expect(logOutput.contains('bana*'), equals(true));
 
     File(tracker.jsonFileName).deleteSync();
-    File(tracker.logFileName).deleteSync();
+    File(tracker.tableFileName).deleteSync();
   });
 }

--- a/test/tracker_test.dart
+++ b/test/tracker_test.dart
@@ -1,0 +1,66 @@
+/// Copyright (C) 2021 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// tracker_test.dart
+/// Test the tracker
+///
+/// 2021 December 6
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_vf/rohd_vf.dart';
+import 'package:test/test.dart';
+
+class FruitEvent implements Trackable {
+  final LogicValues apple;
+  final String banana;
+  final int carrot;
+
+  FruitEvent(this.apple, this.banana, this.carrot);
+
+  @override
+  String? trackerString(TrackerField field) {
+    switch (field.title) {
+      case 'Apple':
+        return apple.toString();
+      case 'Banana':
+        return banana;
+      case 'Carrot':
+        return carrot.toString();
+    }
+    return null;
+  }
+}
+
+void main() {
+  test('tracker test', () {
+    var tracker = Tracker(
+      'testTracker',
+      [
+        TrackerField('Apple', 10),
+        TrackerField('Banana', 5),
+        TrackerField('Carrot', 12)
+      ],
+    );
+
+    tracker.record(FruitEvent(LogicValues.fromString('1x0'), 'banana', 25));
+    tracker.record(
+        FruitEvent(LogicValues.fromString('1x01111000011010101'), 'aaa', 4));
+
+    tracker.terminate();
+
+    var jsonOutput = json.decode(File(tracker.jsonFileName).readAsStringSync());
+    expect(jsonOutput['records'].length, equals(2));
+    expect(jsonOutput['records'][0]['Banana'], equals('banana'));
+
+    var logOutput = File(tracker.logFileName).readAsStringSync();
+    expect(logOutput.contains('bana*'), equals(true));
+
+    File(tracker.jsonFileName).deleteSync();
+    File(tracker.logFileName).deleteSync();
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It is common to want to log events or items throughout the test in an easy-to-read or easy-to-parse way.  The `Tracker` enables both of these by generating a pretty ASCII table and/or a JSON output file of all events from the simulation.

## Related Issue(s)

None

## Testing

Added a new unit test

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

Yes, added more API doc comments and a section in the README
