### PR TITLE
Upgrade ROHD to v0.3.0

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -253,7 +253,7 @@ class CounterDriver extends Driver<CounterSeqItem> {
 }
 
 /// A monitor for the value output of the [Counter]].
-class CounterValueMonitor extends Monitor<LogicValues> {
+class CounterValueMonitor extends Monitor<LogicValue> {
   /// Instance of the [Interface] to the DUT.
   final CounterInterface intf;
 
@@ -289,7 +289,7 @@ class CounterEnableMonitor extends Monitor<CounterSeqItem> {
     // Every positive edge of the clock
     intf.clk.posedge.listen((event) {
       // If the enable bit on the interface is 1
-      if (intf.en.bit == LogicValue.one) {
+      if (intf.en.value == LogicValue.one) {
         // Send out an event with `true` out of this Monitor
         add(CounterSeqItem(true));
       }
@@ -304,7 +304,7 @@ class CounterScoreboard extends Component {
   final Stream<bool> enableStream;
 
   /// A stream which sends out the current value out of the counter once per cycle.
-  final Stream<LogicValues> valueStream;
+  final Stream<LogicValue> valueStream;
 
   /// An instance of the interface to the [Counter].
   final CounterInterface intf;

--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -32,6 +32,8 @@ abstract class Test extends Component {
   /// reproduced by setting the same seed again.
   static Random get random => instance._random;
 
+  //TODO: make this always return a Random, even if no test
+
   /// The minimum level that should immediately kill the test.
   ///
   /// This level should be greater than or equal to [failLevel].
@@ -70,6 +72,8 @@ abstract class Test extends Component {
     instance = this;
     configureLogger();
   }
+
+  //TODO: make it print the random seed
 
   /// Configures the root logger to provide information about
   /// log messages.

--- a/lib/src/tracker.dart
+++ b/lib/src/tracker.dart
@@ -83,6 +83,8 @@ class Tracker<TrackableType extends Trackable> {
   /// A [List] of all [_TrackerDumper]s which are enabled for output dumping.
   late final List<_TrackerDumper<TrackableType>> _dumpers;
 
+  //TODO: constructor doc comments
+
   Tracker(this.name, List<TrackerField> fields,
       {String spacer = ' | ',
       String separator = '-',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   meta: ^1.3.0
-  rohd: ^0.2.0
+  rohd: ^0.3.0
   logging: ^1.0.1
 
 dev_dependencies:

--- a/test/tracker_test.dart
+++ b/test/tracker_test.dart
@@ -16,7 +16,7 @@ import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
 class FruitEvent implements Trackable {
-  final LogicValues apple;
+  final LogicValue apple;
   final String banana;
   final int carrot;
 
@@ -50,9 +50,9 @@ void main() {
       ],
     );
 
-    tracker.record(FruitEvent(LogicValues.ofString('1x0'), 'banana', 25));
+    tracker.record(FruitEvent(LogicValue.ofString('1x0'), 'banana', 25));
     tracker.record(
-        FruitEvent(LogicValues.ofString('1x01111000011010101'), 'aaa', 5));
+        FruitEvent(LogicValue.ofString('1x01111000011010101'), 'aaa', 5));
 
     // Expect JSON log to look like:
     // {"records":[


### PR DESCRIPTION
## Description & Motivation

Upgrading ROHD to v0.3.0 so that ROHD-VF can be used with the latest ROHD.

## Related Issue(s)

N/A

## Testing

Existing tests pass

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

Only so much as ROHD v0.3.0 was not backwards-compatible.
https://github.com/intel/rohd/blob/main/CHANGELOG.md

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
