### PR TITLE
Make sequencer and monitor streams synchronous

### DIFF
--- a/lib/src/monitor.dart
+++ b/lib/src/monitor.dart
@@ -17,7 +17,7 @@ import 'package:rohd_vf/rohd_vf.dart';
 abstract class Monitor<MonitorItem> extends Component {
   /// A controller for the main output [stream] of this [Monitor].
   final StreamController<MonitorItem> _streamController =
-      StreamController<MonitorItem>.broadcast();
+      StreamController<MonitorItem>.broadcast(sync: true);
 
   /// A [Stream] of items that this [Monitor] has detected and shared with listeners.
   ///

--- a/lib/src/sequencer.dart
+++ b/lib/src/sequencer.dart
@@ -25,7 +25,7 @@ class Sequencer<SequenceItemType extends SequenceItem> extends Component {
 
   /// A controller for the output [stream] of this [Sequencer].
   final StreamController<SequenceItemType> _streamController =
-      StreamController<SequenceItemType>();
+      StreamController<SequenceItemType>(sync: true);
 
   /// The output [Stream] of [SequenceItemType] from this [Sequencer], intended
   /// to be consumed by a [Driver].


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Using asynchronous streams on the sequencer and monitor can add unexpected delays.  Moving to synchronous streams makes things more predictable.

## Related Issue(s)

Fix #8 

## Testing

Existing tests cover functionality.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
