### PR TITLE
Make the tracker file writing asynchronous for performance

### DIFF
--- a/test/tracker_test.dart
+++ b/test/tracker_test.dart
@@ -39,7 +39,7 @@ class FruitEvent implements Trackable {
 }
 
 void main() {
-  test('tracker test', () {
+  test('tracker test', () async {
     var tracker = Tracker(
       'testTracker',
       [
@@ -60,7 +60,7 @@ void main() {
     // , {"Apple": "19'b1x01111000011010101", "Banana": "aaa", "Carrot": "4", "Durian": "8"}
     // ]}
 
-    tracker.terminate();
+    await tracker.terminate();
 
     var jsonOutput = json.decode(File(tracker.jsonFileName).readAsStringSync());
     expect(jsonOutput['records'].length, equals(2));


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Writing to files synchronously can cause performance issues on the main program thread.  Writing asynchronously with the tracker can improve test run time.

## Related Issue(s)

Fix #12 

## Testing

Existing test covers it.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, but `Tracker.terminate` is now asynchronous so if it was not safely `await`ed before it could reveal a new issue in usage.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
