### PR TITLE
Fix bugs related to test completion and objections

### DIFF
--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -115,9 +115,24 @@ abstract class Test extends Component {
     }
     unawaited(Simulator.run());
     logger.finest('Waiting for objections to finish...');
-    await runPhase.allObjectionsDropped();
-    logger.finest('Objections completed, ending simulation.');
-    Simulator.endSimulation();
+
+    await Future.any([
+      Simulator.simulationEnded,
+      runPhase.allObjectionsDropped(),
+    ]);
+
+    if (runPhase.objections.isNotEmpty) {
+      logger
+          .warning('Simulation has ended before all objections were dropped!');
+    } else {
+      logger.finest('Objections completed, ending simulation.');
+      Simulator.endSimulation();
+    }
+
+    if (!Simulator.simulationHasEnded) {
+      await Simulator.simulationEnded;
+    }
+
     logger.finest('Simulation ended, test complete.');
   }
 }

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -1,0 +1,62 @@
+/// Copyright (C) 2022 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// test_test.dart
+/// Tests for `Test`
+///
+/// 2022 August 19
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:rohd/rohd.dart';
+import 'package:rohd_vf/rohd_vf.dart';
+import 'package:test/test.dart';
+
+class ForeverObjectionTest extends Test {
+  ForeverObjectionTest() : super('foreverObjectionTest');
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+    phase.raiseObjection('objectionNeverCloses');
+    SimpleClockGenerator(10);
+    Simulator.registerAction(100, () {
+      Simulator.endSimulation();
+    });
+  }
+}
+
+class NormalTest extends Test {
+  NormalTest() : super('normalTest');
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+    var obj = phase.raiseObjection('obj');
+    SimpleClockGenerator(10);
+    Simulator.registerAction(100, () {
+      obj.drop();
+    });
+  }
+}
+
+void main() {
+  setUp(() {
+    Logger.root.level = Level.OFF;
+  });
+
+  tearDown(() {
+    Simulator.reset();
+  });
+
+  test('Test does not wait for objections if simulation ends', () async {
+    await ForeverObjectionTest().start();
+  });
+
+  test('Test.start does not complete until simulation ends', () async {
+    await NormalTest().start();
+    expect(Simulator.simulationHasEnded, isTrue);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Fix bugs so that:
- Objections don't matter anymore once the simulation has completed
- The `Test.start` doesn't finish until the simulation completes

## Related Issue(s)

Fix #9 
Fix #11 

## Testing

Added new tests to cover the bug fixes.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, but if user code relied on buggy functionality there may be some change noticed.

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
