### PR TITLE
bugfix Tracker.record to not discard default values

### DIFF
--- a/lib/src/tracker.dart
+++ b/lib/src/tracker.dart
@@ -137,7 +137,7 @@ class Tracker<TrackableType extends Trackable> {
   void record(TrackableType trackable,
       {Map<String, String?> defaults = const {}}) {
     for (final dumper in _dumpers) {
-      dumper.record(trackable);
+      dumper.record(trackable, defaults: defaults);
     }
   }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->

`Tracker.record` had a bug where it was discarding its `defaults` optional argument as if `defaults` never existed even when given.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here -->
None

## Testing

<!-- Please describe how you tested your changes -->
`tracker_test.dart` has been updated to check to see that the `defaults` argument is used.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

<!--Answer here-->
Nope

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

<!--Answer here-->
Nope; this was the originally intended behavior of `Tracker.record`
