### PR TITLE
Improvements for `Test` failures via `Logger`

### DIFF
--- a/lib/src/component.dart
+++ b/lib/src/component.dart
@@ -9,8 +9,8 @@
 ///
 
 import 'dart:async';
+import 'dart:collection';
 import 'package:meta/meta.dart';
-import 'package:rohd/rohd.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 
 /// The base class for any component in ROHD-VF.
@@ -33,14 +33,14 @@ abstract class Component extends ROHDVFObject {
   final Component? parent;
 
   /// A [List] of all children [Component]s.
+  UnmodifiableListView<Component> get components =>
+      UnmodifiableListView(_components);
   final List<Component> _components = [];
 
   /// Constructs an instance of this [Component] named [name] and with
   /// parent [parent].
   Component(this.name, this.parent) {
     parent?._components.add(this);
-
-    unawaited(Simulator.simulationEnded.then((value) => check()));
   }
 
   /// Returns a [List] of [Component]s representing the full hierarchy

--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -127,6 +127,7 @@ abstract class Test extends Component {
   }
 
   @override
+  @mustCallSuper
   void check() {
     final checkQueue = Queue.of(components);
     while (checkQueue.isNotEmpty) {

--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -107,8 +107,13 @@ abstract class Test extends Component {
 
       if (record.level >= killLevel) {
         failureDetected = true;
+
+        if (record.level >= printLevel) {
+          // ignore: avoid_print
+          print('Killing test due to detected failure.');
+        }
+
         Simulator.endSimulation();
-        // throw Exception('Test killed due to failure.');
       } else if (record.level >= failLevel) {
         if (!failureDetected) {
           if (record.level >= printLevel) {

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -66,6 +66,22 @@ class LogTypeTest extends Test {
   }
 }
 
+class CheckPhaseFailureTest extends Test {
+  CheckPhaseFailureTest()
+      : super('checkPhaseFailureTest', printLevel: Level.OFF) {
+    FailingSubComponent(this);
+  }
+}
+
+class FailingSubComponent extends Component {
+  FailingSubComponent(Component parent) : super('failingSubComponent', parent);
+
+  @override
+  void check() {
+    logger.severe('Failure during check');
+  }
+}
+
 void main() {
   setUp(() {
     Logger.root.level = Level.WARNING;
@@ -112,5 +128,17 @@ void main() {
 
   test('Logger normal message passes', () async {
     await LogTypeTest(Level.WARNING).start();
+  });
+
+  test('Failure during check causes test failure', () async {
+    var sawError = false;
+
+    try {
+      await CheckPhaseFailureTest().start();
+    } on Exception {
+      sawError = true;
+    }
+
+    expect(sawError, isTrue);
   });
 }

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -9,14 +9,13 @@
 ///
 
 import 'dart:async';
-
 import 'package:logging/logging.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
 class ForeverObjectionTest extends Test {
-  ForeverObjectionTest() : super('foreverObjectionTest');
+  ForeverObjectionTest() : super('foreverObjectionTest', printLevel: Level.OFF);
 
   @override
   Future<void> run(Phase phase) async {
@@ -38,9 +37,38 @@ class NormalTest extends Test {
   }
 }
 
+class LogTypeTest extends Test {
+  final Level errorLevel;
+
+  bool testCompleted = false;
+
+  final Logic _clk = SimpleClockGenerator(10).clk;
+
+  LogTypeTest(this.errorLevel) : super('logTypeTest', printLevel: Level.OFF) {
+    Simulator.setMaxSimTime(500);
+  }
+
+  @override
+  Future<void> run(Phase phase) async {
+    unawaited(super.run(phase));
+
+    final obj = phase.raiseObjection();
+
+    await _clk.nextPosedge;
+
+    logger.log(errorLevel, 'error message');
+
+    await _clk.nextPosedge;
+
+    testCompleted = true;
+
+    obj.drop();
+  }
+}
+
 void main() {
   setUp(() {
-    Logger.root.level = Level.OFF;
+    Logger.root.level = Level.WARNING;
   });
 
   tearDown(Simulator.reset);
@@ -52,5 +80,37 @@ void main() {
   test('Test.start does not complete until simulation ends', () async {
     await NormalTest().start();
     expect(Simulator.simulationHasEnded, isTrue);
+  });
+
+  test('Logger failure causes exception at end of test', () async {
+    var sawError = false;
+    final logTest = LogTypeTest(Level.SEVERE);
+
+    try {
+      await logTest.start();
+    } on Exception {
+      sawError = true;
+    }
+
+    expect(sawError, isTrue);
+    expect(logTest.testCompleted, isTrue);
+  });
+
+  test('Logger kill causes exception immediately', () async {
+    var sawError = false;
+    final logTest = LogTypeTest(Level.SHOUT);
+
+    try {
+      await logTest.start();
+    } on Exception {
+      sawError = true;
+    }
+
+    expect(sawError, isTrue);
+    expect(logTest.testCompleted, isFalse);
+  });
+
+  test('Logger normal message passes', () async {
+    await LogTypeTest(Level.WARNING).start();
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

- Sub-`components` now accessible in `Component`s
- The `check` phase now runs synchronously at the end of the `Test` rather than triggered through the ROHD `Simulator`, giving greater control when handling error conditions.
- Added `printLevel` to control printing independently of `Logger` level, which can also disable failures/kills.
- Made handling of test failures/kills more robust and easier to handle.
- Fixed a bug where `Logger` subscriptions could persist across tests.
- Added more `Test` tests to cover these areas.
- Fixed a bug where failures reported via the `Logger` and found during check phase would sometimes not cause a test to fail.

## Related Issue(s)

None

## Testing

Added new testing, and existing tests pass

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No, shouldn't be


## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

<!--Answer here-->
