### PR TITLE
Remove requirement to call super on check for tests

### DIFF
--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -127,10 +127,8 @@ abstract class Test extends Component {
     });
   }
 
-  @override
-  @mustCallSuper
-  void check() {
-    final checkQueue = Queue.of(components);
+  void _checkAll() {
+    final checkQueue = Queue.of([this, ...components]);
     while (checkQueue.isNotEmpty) {
       final component = checkQueue.removeFirst();
       checkQueue.addAll(component.components);
@@ -172,7 +170,7 @@ abstract class Test extends Component {
     }
 
     logger.finest('Running end of test checks.');
-    check();
+    _checkAll();
 
     logger.finest('Simulation ended, test complete.');
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It's inconvenient for users to have to call `super.check()`, especially since it's important that it's called at the end of the `check()` instead of at the top.  Moving the mechanism that `Test` uses to call `check()` on all sub-components removes the need to call super's and avoids bugs.

## Related Issue(s)

N/A

## Testing

Existing tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible?  If yes, how so?

No

## Documentation

> Does the change require any updates to documentation?  If so, where?  Are they included?

No
