### PR TITLE
Fix dart doc check and doc bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A testbench is software used to interact with and test a device under test (DUT)
 
 ### Example
 
-Dive right in with a full [example testbench for a counter](example/main.dart).  The example includes `Monitor`s, a `Driver`, a `Sequencer`, an `Agent`, an `Env`, a `Test`, the same DUT as the ROHD counter example, a `Sequence` with `SequenceItem`s, a scoreboard, and a main function to kick it all off, all in a single commented file.
+Dive right in with a full [example testbench for a counter](https://github.com/intel/rohd-vf/raw/main/example/main.dart).  The example includes `Monitor`s, a `Driver`, a `Sequencer`, an `Agent`, an `Env`, a `Test`, the same DUT as the ROHD counter example, a `Sequence` with `SequenceItem`s, a scoreboard, and a main function to kick it all off, all in a single commented file.
 
 ### Constructing Objects
 The ROHD Verification Framework does not come with a built-in "factory" (like UVM) for constructing `Component`s in the testbench.  Instead, objects can just be constructed like any other object.  It is a good idea to build a testbench with modularity and configurability in mind so that behavior can be easily changed depending on the desired test.  There is no restriction against using a factory design pattern to build a testbench if that's the right approach for a specific situation.  You also might be interested in using other approaches, such as dependency injection.  ROHD-VF doesn't push a strong opinion here.
@@ -84,7 +84,7 @@ The `Test` object contains settings for `killLevel` and `failLevel` which will, 
 To log a message from any ROHD-VF object or component, just use the inherited `logger` object.
 
 ### Logging with the `Tracker`
-ROHD-VF comes with a flexible [`Tracker`](https://intel.github.io/rohd-vf/rohd_vf/Tracker-class.html) which enables pretty printing and convenient output files associated with arbitrary events (which implement [`Trackable`](https://intel.github.io/rohd-vf/rohd_vf/Trackable-class.html)) throughout your test.  `Tracker` currently supports a JSON output as well as an ASCII table output.  Check out the [tracker unit test](./test/tracker_test.dart) for an example of how to configure and use the `Tracker`.
+ROHD-VF comes with a flexible [`Tracker`](https://intel.github.io/rohd-vf/rohd_vf/Tracker-class.html) which enables pretty printing and convenient output files associated with arbitrary events (which implement [`Trackable`](https://intel.github.io/rohd-vf/rohd_vf/Trackable-class.html)) throughout your test.  `Tracker` currently supports a JSON output as well as an ASCII table output.  Check out the [tracker unit test](https://github.com/intel/rohd-vf/raw/main/test/tracker_test.dart) for an example of how to configure and use the `Tracker`.
 
 ----------------
 2021 November 9  

--- a/tool/gh_actions/check_documentation.sh
+++ b/tool/gh_actions/check_documentation.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # check_documentation.sh
@@ -18,12 +18,13 @@ set -euo pipefail
 #   https://github.com/dart-lang/dartdoc/issues/2907
 #   https://github.com/dart-lang/dartdoc/issues/1959
 
-output=$(dart doc --validate-links --dry-run 2>&1 | tee)
+output=$(dart doc --validate-links 2>&1 | tee)
 
-# In case of problems, the variable will contain a non-empty string.
-if [ -z "${output}" ]; then
+# In case of problems, the searched substring will not be found.
+if echo "${output}" | grep --silent 'no issues found'; then
   echo 'Documentation check passed!'
 else
   echo "${output}"
+  echo 'Documentation failed since some issues were found'
   exit 1
 fi


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The `check_documentation.sh` script didn't quite check exactly the same thing as `generate_documentation.sh`.  Unfortunately the "generate" was stricter, meaning that even though a PR passed CI, it failed to generate documentation properly in CD.

This change makes it consistent and also fixes the escaped doc bugs.

## Related Issue(s)

N/A

## Testing

Ran `check_documentation.sh` locally with new changes with and without doc fixes.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, includes fixes to remove warnings