### PR TITLE
Fix behavior of any edge

### DIFF
--- a/lib/src/waiter.dart
+++ b/lib/src/waiter.dart
@@ -27,6 +27,10 @@ extension LogicWaiter on Logic {
   /// where each cycle is defined as the next occurence of the specified [edge].
   ///
   /// [width] must be 1 or an [Exception] will be thrown.
+  ///
+  /// Like [nextNegedge] and [nextPosedge], this will only detect valid edge
+  /// transitions. If the value is invalid (`x` or `z`) before or after the
+  /// transition, it will not count as a cycle.
   Future<void> waitCycles(int numCycles, {Edge edge = Edge.pos}) async {
     if (width != 1) {
       throw Exception('Must be a 1-bit signal, but was $width bits.');
@@ -41,7 +45,10 @@ extension LogicWaiter on Logic {
           await nextNegedge;
           break;
         case Edge.any:
-          await nextChanged;
+          await Future.any([
+            nextPosedge,
+            nextNegedge,
+          ]);
           break;
       }
     }

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -108,7 +108,9 @@ void main() {
     Logger.root.level = Level.WARNING;
   });
 
-  tearDown(Simulator.reset);
+  tearDown(() async {
+    await Simulator.reset();
+  });
 
   test('Test does not wait for objections if simulation ends', () async {
     await ForeverObjectionTest().start();

--- a/test/waiter_test.dart
+++ b/test/waiter_test.dart
@@ -1,0 +1,95 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// waiter_test.dart
+// Test the waiter
+//
+// 2023 September 25
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'dart:async';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_vf/src/waiter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Logic clk;
+  setUp(() {
+    Simulator.setMaxSimTime(500);
+    clk = SimpleClockGenerator(10).clk;
+  });
+
+  tearDown(() async {
+    await Simulator.reset();
+  });
+
+  test('0 cycles is instant', () async {
+    Simulator.registerAction(18, () async {
+      await clk.waitCycles(0);
+      expect(Simulator.time, 18);
+    });
+
+    unawaited(Simulator.run());
+
+    await clk.waitCycles(0);
+
+    expect(Simulator.time, 5);
+
+    await Simulator.simulationEnded;
+  });
+
+  test('pos', () async {
+    var checkHappened = false;
+
+    Simulator.registerAction(18, () {
+      // 25, 35, 45
+      clk.waitCycles(3).then((value) {
+        expect(Simulator.time, 45);
+        checkHappened = true;
+      });
+    });
+
+    unawaited(Simulator.run());
+
+    await Simulator.simulationEnded;
+
+    expect(checkHappened, isTrue);
+  });
+
+  test('neg', () async {
+    var checkHappened = false;
+
+    Simulator.registerAction(18, () {
+      // 20, 30, 40
+      clk.waitCycles(3, edge: Edge.neg).then((value) {
+        expect(Simulator.time, 40);
+        checkHappened = true;
+      });
+    });
+
+    unawaited(Simulator.run());
+
+    await Simulator.simulationEnded;
+
+    expect(checkHappened, isTrue);
+  });
+
+  test('any', () async {
+    var checkHappened = false;
+
+    Simulator.registerAction(18, () {
+      // 20, 25, 30
+      clk.waitCycles(3, edge: Edge.any).then((value) {
+        expect(Simulator.time, 30);
+        checkHappened = true;
+      });
+    });
+
+    unawaited(Simulator.run());
+
+    await Simulator.simulationEnded;
+
+    expect(checkHappened, isTrue);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Before this PR, any change from `Logic.changed` could trigger an `any` edge in `waitCycles`, which is confusing and inconsistent.  Now, `any` really means either `neg` or `pos`, as described in the documentation.

## Related Issue(s)

N/A

## Testing

Added new tests

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No