### PR TITLE
Fix Issue rohd-vf#45

### DIFF
--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -128,7 +128,7 @@ abstract class Test extends Component {
   }
 
   void _checkAll() {
-    final checkQueue = Queue.of([this, ...components]);
+    final checkQueue = Queue<Component>.of([this]);
     while (checkQueue.isNotEmpty) {
       final component = checkQueue.removeFirst();
       checkQueue.addAll(component.components);

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -74,11 +74,17 @@ class CheckPhaseFailureTest extends Test {
 }
 
 class FailingSubComponent extends Component {
+  int chkphasecnt = 0;
+
   FailingSubComponent(Component parent) : super('failingSubComponent', parent);
 
   @override
   void check() {
-    logger.severe('Failure during check');
+    chkphasecnt += 1;
+    
+    if (chkphasecnt != 1) {
+      logger.severe('Failure during check');
+    }
   }
 }
 
@@ -139,6 +145,6 @@ void main() {
       sawError = true;
     }
 
-    expect(sawError, isTrue);
+    expect(sawError, isFalse);
   });
 }

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -74,15 +74,15 @@ class CheckPhaseFailureTest extends Test {
 }
 
 class FailingSubComponent extends Component {
-  int chkphasecnt = 0;
+  int checkPhaseCount = 0;
 
   FailingSubComponent(Component parent) : super('failingSubComponent', parent);
 
   @override
   void check() {
-    chkphasecnt += 1;
+    checkPhaseCount += 1;
     
-    if (chkphasecnt != 1) {
+    if (checkPhaseCount != 1) {
       logger.severe('Failure during check');
     }
   }


### PR DESCRIPTION
## Description & Motivation

Fix Issue rohd-vf#45, Initial checkQueue now only has the component Test not all components instantiated below it.

## Related Issue(s)

rohd-vf#45

## Testing

Test cases are already in place to reproduce the bug, and these tests have been updated after implementing the fix to ensure they no longer fail.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No