### PR TITLE
Fix Issue rohd-vf#45

### DIFF
--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -128,7 +128,7 @@ abstract class Test extends Component {
   }
 
   void _checkAll() {
-    final checkQueue = Queue.of([this, ...components]);
+    final checkQueue = Queue<Component>.of([this]);
     while (checkQueue.isNotEmpty) {
       final component = checkQueue.removeFirst();
       checkQueue.addAll(component.components);

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -82,6 +82,28 @@ class FailingSubComponent extends Component {
   }
 }
 
+class CheckPhaseCalledOnceTest extends Test {
+  CheckPhaseCalledOnceTest()
+      : super('checkPhaseCalledOnceTest', printLevel: Level.OFF) {
+    CheckPhaseFailingSubComponent(this);
+  }
+}
+
+class CheckPhaseFailingSubComponent extends Component {
+  int checkPhaseCount = 0;
+
+  CheckPhaseFailingSubComponent(Component parent)
+      : super('checkPhaseFailingSubComponent', parent);
+
+  @override
+  void check() {
+    checkPhaseCount += 1;
+    if (checkPhaseCount > 1) {
+      logger.severe('Check Phase called $checkPhaseCount times');
+    }
+  }
+}
+
 void main() {
   setUp(() {
     Logger.root.level = Level.WARNING;
@@ -140,5 +162,17 @@ void main() {
     }
 
     expect(sawError, isTrue);
+  });
+
+  test('Check is only called once on components directly under Test', () async {
+    var sawError = false;
+
+    try {
+      await CheckPhaseCalledOnceTest().start();
+    } on Exception {
+      sawError = true;
+    }
+
+    expect(sawError, isFalse);
   });
 }


### PR DESCRIPTION
## Description & Motivation

Fix Issue rohd-vf#45, Initial checkQueue now only has the component Test not all components instantiated below it.

## Related Issue(s)

rohd-vf#45

## Testing

Created a test to reproduce the bug

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Np

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No