### PR TITLE
Allow end of test empty check to be disabled

### DIFF
--- a/lib/src/drivers/pending_clocked_driver.dart
+++ b/lib/src/drivers/pending_clocked_driver.dart
@@ -37,6 +37,7 @@ abstract class PendingClockedDriver<SequenceItemType extends SequenceItem>
     this.timeoutCycles,
     this.dropDelayCycles,
     this.waitEdge = Edge.pos,
+    super.enableEndOfTestEmptyCheck,
   }) : super(
           timeout: timeoutCycles != null
               ? () async {

--- a/lib/src/drivers/pending_driver.dart
+++ b/lib/src/drivers/pending_driver.dart
@@ -41,9 +41,19 @@ abstract class PendingDriver<SequenceItemType extends SequenceItem>
   /// further activity before it completes.
   final Future<void> Function()? dropDelay;
 
+  /// If `true`, will [check] at the end of the test that there are no pending
+  /// items remaining to be driven.
+  final bool enableEndOfTestEmptyCheck;
+
   /// Creates a new [PendingDriver] attached to [sequencer].
-  PendingDriver(super.name, super.parent,
-      {required super.sequencer, this.timeout, this.dropDelay}) {
+  PendingDriver(
+    super.name,
+    super.parent, {
+    required super.sequencer,
+    this.timeout,
+    this.dropDelay,
+    this.enableEndOfTestEmptyCheck = true,
+  }) {
     pendingSeqItems = _PendingQueue<SequenceItemType>(
       parent: this,
       timeout: timeout,
@@ -64,7 +74,7 @@ abstract class PendingDriver<SequenceItemType extends SequenceItem>
 
   @override
   void check() {
-    if (pendingSeqItems.isNotEmpty) {
+    if (pendingSeqItems.isNotEmpty && enableEndOfTestEmptyCheck) {
       logger.severe('At end of test, there were still pending items to send.');
 
       for (final seqItem in pendingSeqItems) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Allow the "end of test empty check" for `PendingDriver` and `PendingClockedDriver` to be disabled via `enableEndOfTestEmptyCheck` flag.

## Related Issue(s)

N/A

## Testing

Added tests covering it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

API docs updated