### PR TITLE
Updated example to ROHD APIs in a better way

### DIFF
--- a/example/counter.dart
+++ b/example/counter.dart
@@ -32,14 +32,9 @@ class CounterInterface extends Interface<CounterDirection> {
   }
 }
 
-/// A simple counter which increments once per [clk] edge whenever
-/// [en] is high, and [reset]s to 0, with output [val].
+/// A simple counter which increments once per `clk` edge whenever
+/// `en` is high, and `reset`s to 0, with output `val`.
 class Counter extends Module {
-  Logic get clk => input('clk');
-  Logic get en => input('en');
-  Logic get reset => input('reset');
-  Logic get val => output('val');
-
   late final CounterInterface intf;
 
   Counter(CounterInterface intf) : super(name: 'counter') {
@@ -54,14 +49,10 @@ class Counter extends Module {
   void _buildLogic() {
     final nextVal = Logic(name: 'nextVal', width: intf.width);
 
-    nextVal <= val + 1;
+    nextVal <= intf.val + 1;
 
-    Sequential(clk, [
-      If(reset, then: [
-        val < 0
-      ], orElse: [
-        If(en, then: [val < nextVal])
-      ])
+    Sequential(intf.clk, reset: intf.reset, [
+      If(intf.en, then: [intf.val < nextVal])
     ]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,13 +7,13 @@ issue_tracker: https://github.com/intel/rohd-vf/issues
 documentation: https://intel.github.io/rohd-vf/rohd_vf/rohd_vf-library.html
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
   async: ^2.11.0
   logging: ^1.0.1
   meta: ^1.3.0
-  rohd: ^0.4.0
+  rohd: ^0.5.0
 
 dev_dependencies:
   test: ^1.17.3


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

The ROHD-VF example passed the DUT around instead of an interface, and used `input` and `output` to access ports of that interface, which isn't really the best way.  Adjusted the example to use the interface a better way.

The `previousValue` API also makes it possible to simplify the example.

Upgrade ROHD to v0.5.0

## Related Issue(s)

N/A

## Testing

Tests already cover it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, upgrade ROHD to v0.5.0