### PR TITLE
Expose random seed and make static test nullable

### DIFF
--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -98,6 +98,20 @@ abstract class Test extends Component {
     configureLogger();
   }
 
+  /// Resets static awareness of the [Simulator] and [Test] to a safe initial
+  /// state.
+  ///
+  /// This includes a call to [Simulator.reset] and clearing the [instance]
+  /// reference to `null`.
+  ///
+  /// This is important, for example, if you're running a variety of tests in
+  /// unit test suite.
+  static Future<void> reset() async {
+    await Simulator.reset();
+
+    _instance = null;
+  }
+
   /// A handle to the subscription to the root [Logger], so that it
   /// can be cancelled at the end of the test.
   late final StreamSubscription<LogRecord> _loggerSubscription;

--- a/lib/src/test.dart
+++ b/lib/src/test.dart
@@ -30,6 +30,8 @@ abstract class Test extends Component {
   /// which can be manually overriden.  If all random behavior in
   /// the test derives from [random] object, then tests can be
   /// reproduced by setting the same seed again.
+  ///
+  /// This is `null` if [instance] is `null`.
   static Random? get random => instance?._random;
 
   /// The minimum level that should immediately kill the test.
@@ -51,7 +53,10 @@ abstract class Test extends Component {
   /// [Exception].
   bool failureDetected = false;
 
-  /// The singleton Test for this simulation.
+  /// The singleton [Test] for this simulation.
+  ///
+  /// It is `null` if there is no currently active [Test].  It is set back to
+  /// `null` after a it is finished running.
   static Test? get instance => _instance;
   static Test? _instance;
 

--- a/test/counter_example_test.dart
+++ b/test/counter_example_test.dart
@@ -9,12 +9,13 @@
 
 import 'package:logging/logging.dart';
 import 'package:rohd/rohd.dart';
+import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 import '../example/main.dart' as example;
 
 void main() {
   tearDown(() async {
-    await Simulator.reset();
+    await Test.reset();
   });
 
   test('counter example test', () async {

--- a/test/counter_example_test.dart
+++ b/test/counter_example_test.dart
@@ -8,7 +8,6 @@
 // Author: Max Korbel <max.korbel@intel.com>
 
 import 'package:logging/logging.dart';
-import 'package:rohd/rohd.dart';
 import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 import '../example/main.dart' as example;

--- a/test/pending_driver_test.dart
+++ b/test/pending_driver_test.dart
@@ -84,7 +84,7 @@ void main() {
   });
 
   tearDown(() async {
-    await Simulator.reset();
+    await Test.reset();
   });
 
   test('pending driver simple', () async {

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -26,7 +26,7 @@ class ForeverObjectionTest extends Test {
 }
 
 class NormalTest extends Test {
-  NormalTest() : super('normalTest');
+  NormalTest() : super('normalTest', randomSeed: 123);
   @override
   Future<void> run(Phase phase) async {
     unawaited(super.run(phase));
@@ -175,5 +175,24 @@ void main() {
     }
 
     expect(sawError, isFalse);
+  });
+
+  group('Test.instance', () {
+    test('test already created', () async {
+      NormalTest();
+
+      expect(Test.instance, isNotNull);
+      expect(Test.random, isNotNull);
+      expect(Test.instance!.randomSeed, 123);
+
+      await Test.instance!.start();
+
+      expect(Test.instance, isNull);
+    });
+
+    test('test not created', () {
+      expect(Test.instance, isNull);
+      expect(Test.random, isNull);
+    });
   });
 }

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -109,7 +109,7 @@ void main() {
   });
 
   tearDown(() async {
-    await Simulator.reset();
+    await Test.reset();
   });
 
   test('Test does not wait for objections if simulation ends', () async {

--- a/test/waiter_test.dart
+++ b/test/waiter_test.dart
@@ -10,7 +10,7 @@
 import 'dart:async';
 
 import 'package:rohd/rohd.dart';
-import 'package:rohd_vf/src/waiter.dart';
+import 'package:rohd_vf/rohd_vf.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,7 +21,7 @@ void main() {
   });
 
   tearDown(() async {
-    await Simulator.reset();
+    await Test.reset();
   });
 
   test('0 cycles is instant', () async {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This PR refactors some parts of the `Test` API.

- Static members related to `Test.instance`, including `Test.random`, are now nullable instead of `late`.  This highlights the need for a `Test` to be constructed before using those variables, and avoids confusing late initialization errors.
- Expose the `randomSeed` for `Test`s so that it can be queried, printed, etc. to make it easier to reproduce issues.
- Make the `Test.instance` `null` out after a test has run, so that it doesn't stick around afterwards, which could cause some confusion.
- Adds `Test.reset()` to reset the `Test.instance`.

## Related Issue(s)

Fix #24 
Fix #23

## Testing

Added tests around these changes

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

YES!
- `Test.instance` and `Test.random` are now nullable
- `Test.instance` is now a `get`ter only.
- `Test.instance` is now null after a test is finished running.
- A `Test` will fail to construct (exception) if there's already an instance running.
- Should now use `Test.reset()` (which includes `Simulator.reset()`)

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

API docs are updated