### PR TITLE
Update default permissions in GH actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+# Top-level default, no permissions
+permissions: {}
+
 jobs:
   run-checks:
     name: Run Checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Updates ROHD dependency to at least v0.5.0
 - Breaking: `Test.instance` is now nullable and `null` when no `Test` is active, which also impacts `Test.random`. Use `Test.reset` instead of `Simulator.reset` in ROHD-VF testbenches to reset.
-- Added `QuesceObjector`, `PendingDriver`, and `PendingClockedDriver` to make it easier to develop typical drivers.
+- Added `QuiesceObjector`, `PendingDriver`, and `PendingClockedDriver` to make it easier to develop typical drivers.
 - Added `waitCycles` function as an extension to `Logic` to make it easier to wait for a variable number of clock edges.
 - Fixed a bug where `Component`s directly under the `Test` could run the `check` phase multiple times (<https://github.com/intel/rohd-vf/issues/45>).
 - Updated the example, leveraging some new APIs in ROHD-VF and ROHD and demonstrating best practices.


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It is safest to put a default permissions in GitHub Actions workflows.
 
Also, update typo in CHANGELOG.md.

## Related Issue(s)

N/A

## Testing

This PR will test it.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No