### PR TITLE
Add compatibility with ROHD v0.6.0 and improve stability

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -97,7 +97,7 @@ class CounterTest extends Test {
     Simulator.registerAction(3, () {
       intf.reset.put(1);
     });
-    Simulator.registerAction(35, () {
+    Simulator.registerAction(33, () {
       intf.reset.put(0);
     });
 

--- a/lib/src/drivers/pending_driver.dart
+++ b/lib/src/drivers/pending_driver.dart
@@ -85,7 +85,7 @@ abstract class PendingDriver<SequenceItemType extends SequenceItem>
 }
 
 /// A special version of [ListQueue] that uses a [QuiesceObjector].
-class _PendingQueue<E> extends ListQueue<E> {
+class _PendingQueue<E> implements Queue<E> {
   final Component parent;
 
   final Future<void> Function()? timeout;
@@ -93,7 +93,19 @@ class _PendingQueue<E> extends ListQueue<E> {
 
   late final QuiesceObjector _quiesceObjector;
 
-  _PendingQueue({
+  final ListQueue<E> _listQueue = ListQueue<E>();
+
+  factory _PendingQueue(
+          {required Component parent,
+          required Future<void> Function()? timeout,
+          required Future<void> Function()? dropDelay}) =>
+      _PendingQueue._(
+        parent: parent,
+        timeout: timeout,
+        dropDelay: dropDelay,
+      );
+
+  _PendingQueue._({
     required this.parent,
     required this.timeout,
     required this.dropDelay,
@@ -111,64 +123,163 @@ class _PendingQueue<E> extends ListQueue<E> {
 
   @override
   void add(E value) {
-    super.add(value);
+    _listQueue.add(value);
     _reconsiderObjection();
   }
 
   @override
   void addAll(Iterable<E> iterable) {
-    super.addAll(iterable);
+    _listQueue.addAll(iterable);
     _reconsiderObjection();
   }
 
   @override
   void addFirst(E value) {
-    super.addFirst(value);
+    _listQueue.addFirst(value);
     _reconsiderObjection();
   }
 
   @override
   void addLast(E value) {
-    super.addLast(value);
+    _listQueue.addLast(value);
     _reconsiderObjection();
   }
 
   @override
   void clear() {
-    super.clear();
+    _listQueue.clear();
     _reconsiderObjection();
   }
 
   @override
   bool remove(Object? value) {
-    final res = super.remove(value);
+    final res = _listQueue.remove(value);
     _reconsiderObjection();
     return res;
   }
 
   @override
   E removeFirst() {
-    final res = super.removeFirst();
+    final res = _listQueue.removeFirst();
     _reconsiderObjection();
     return res;
   }
 
   @override
   E removeLast() {
-    final res = super.removeLast();
+    final res = _listQueue.removeLast();
     _reconsiderObjection();
     return res;
   }
 
   @override
   void removeWhere(bool Function(E element) test) {
-    super.removeWhere(test);
+    _listQueue.removeWhere(test);
     _reconsiderObjection();
   }
 
   @override
   void retainWhere(bool Function(E element) test) {
-    super.retainWhere(test);
+    _listQueue.retainWhere(test);
     _reconsiderObjection();
   }
+
+  @override
+  bool any(bool Function(E element) test) => _listQueue.any(test);
+
+  @override
+  Queue<R> cast<R>() => _listQueue.cast<R>();
+
+  @override
+  bool contains(Object? element) => _listQueue.contains(element);
+
+  @override
+  E elementAt(int index) => _listQueue.elementAt(index);
+
+  @override
+  bool every(bool Function(E element) test) => _listQueue.every(test);
+
+  @override
+  Iterable<T> expand<T>(Iterable<T> Function(E element) toElements) =>
+      _listQueue.expand(toElements);
+
+  @override
+  E get first => _listQueue.first;
+
+  @override
+  E firstWhere(bool Function(E element) test, {E Function()? orElse}) =>
+      _listQueue.firstWhere(test, orElse: orElse);
+
+  @override
+  T fold<T>(T initialValue, T Function(T previousValue, E element) combine) =>
+      _listQueue.fold(initialValue, combine);
+
+  @override
+  Iterable<E> followedBy(Iterable<E> other) => _listQueue.followedBy(other);
+
+  @override
+  void forEach(void Function(E element) action) => _listQueue.forEach(action);
+
+  @override
+  bool get isEmpty => _listQueue.isEmpty;
+
+  @override
+  bool get isNotEmpty => _listQueue.isNotEmpty;
+
+  @override
+  Iterator<E> get iterator => _listQueue.iterator;
+
+  @override
+  String join([String separator = '']) => _listQueue.join(separator);
+
+  @override
+  E get last => _listQueue.last;
+
+  @override
+  E lastWhere(bool Function(E element) test, {E Function()? orElse}) =>
+      _listQueue.lastWhere(test, orElse: orElse);
+
+  @override
+  int get length => _listQueue.length;
+
+  @override
+  Iterable<T> map<T>(T Function(E e) toElement) => _listQueue.map(toElement);
+
+  @override
+  E reduce(E Function(E value, E element) combine) =>
+      _listQueue.reduce(combine);
+
+  @override
+  E get single => _listQueue.single;
+
+  @override
+  E singleWhere(bool Function(E element) test, {E Function()? orElse}) =>
+      _listQueue.singleWhere(test, orElse: orElse);
+
+  @override
+  Iterable<E> skip(int count) => _listQueue.skip(count);
+
+  @override
+  Iterable<E> skipWhile(bool Function(E value) test) =>
+      _listQueue.skipWhile(test);
+
+  @override
+  Iterable<E> take(int count) => _listQueue.take(count);
+
+  @override
+  Iterable<E> takeWhile(bool Function(E value) test) =>
+      _listQueue.takeWhile(test);
+
+  @override
+  List<E> toList({bool growable = true}) =>
+      _listQueue.toList(growable: growable);
+
+  @override
+  Set<E> toSet() => _listQueue.toSet();
+
+  @override
+  Iterable<E> where(bool Function(E element) test) => _listQueue.where(test);
+
+  @override
+  Iterable<T> whereType<T>() => _listQueue.whereType<T>();
 }

--- a/lib/src/waiter.dart
+++ b/lib/src/waiter.dart
@@ -40,16 +40,13 @@ extension LogicWaiter on Logic {
       switch (edge) {
         case Edge.pos:
           await nextPosedge;
-          break;
         case Edge.neg:
           await nextNegedge;
-          break;
         case Edge.any:
           await Future.any([
             nextPosedge,
             nextNegedge,
           ]);
-          break;
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,13 +7,13 @@ issue_tracker: https://github.com/intel/rohd-vf/issues
 documentation: https://intel.github.io/rohd-vf/rohd_vf/rohd_vf-library.html
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   async: ^2.11.0
   logging: ^1.0.1
   meta: ^1.3.0
-  rohd: ^0.5.0
+  rohd: ^0.6.0
 
 dev_dependencies:
   test: ^1.17.3

--- a/test/test_test.dart
+++ b/test/test_test.dart
@@ -177,6 +177,31 @@ void main() {
     expect(sawError, isFalse);
   });
 
+  test('exception at end of sim action', () async {
+    final test = NormalTest()..printLevel = Level.OFF;
+
+    Object? seenError;
+    Logger.root.onRecord.listen((record) {
+      if (record.error != null) {
+        seenError = record.error;
+      }
+    });
+
+    Simulator.registerEndOfSimulationAction(() async {
+      throw Exception('endofsim');
+    });
+
+    try {
+      await test.start();
+      fail('Expected exception to be thrown.');
+    } on Exception catch (e) {
+      expect(e.toString(), contains('Test failed.'));
+    }
+
+    expect(seenError, isNotNull);
+    expect(seenError.toString(), contains('endofsim'));
+  });
+
   group('Test.instance', () {
     test('test already created', () async {
       NormalTest();

--- a/test/waiter_test.dart
+++ b/test/waiter_test.dart
@@ -34,7 +34,7 @@ void main() {
 
     await clk.waitCycles(0);
 
-    expect(Simulator.time, 5);
+    expect(Simulator.time, 0);
 
     await Simulator.simulationEnded;
   });

--- a/tool/gh_actions/generate_documentation.sh
+++ b/tool/gh_actions/generate_documentation.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 #   https://github.com/dart-lang/dartdoc/issues/2907
 #   https://github.com/dart-lang/dartdoc/issues/1959
 
-# Disabling --validate-links due to https://github.com/dart-lang/dartdoc/issues/3584
+# Disabling --validate-links due to
+#   https://github.com/dart-lang/dartdoc/issues/3584
+#   https://github.com/dart-lang/dartdoc/issues/3939
 # output=$(dart doc --validate-links 2>&1 | tee)
 output=$(dart doc 2>&1 | tee)
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

A collection of small changes related to compatibility with ROHD v0.6.0 and improved stability.

- Fixed #58 so that exceptions in the `Simulator` don't cause hangs in tests
- Refactored implementation of a queue to support sealed classes from Dart
- Fixed some minor lint issues

## Related Issue(s)

Fix #58

## Testing

Added tests where relevant, existing covers most of it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Yes!

- Minimum Dart SDK moved to 3.0.0
- ROHD v0.6.0 required

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No